### PR TITLE
Support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     },
     "require": {
         "php": ">=7.1",
-        "laravel/framework": "^5.6"
+        "laravel/framework": "^6.0"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
         "phpunit/phpunit": "~7.0",
         "squizlabs/php_codesniffer" : "1.5.*",
-        "laravel/laravel": "^5.6",
+        "laravel/laravel": "^6.0",
         "satooshi/php-coveralls" : "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,14 @@
     },
     "require": {
         "php": ">=7.1",
-        "laravel/framework": "^6.0"
+        "laravel/framework": "^5.6|^6.0",
+        "laravel/helpers": "^1.1"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
         "phpunit/phpunit": "~7.0",
         "squizlabs/php_codesniffer" : "1.5.*",
-        "laravel/laravel": "^6.0",
+        "laravel/laravel": "^5.6|^6.0",
         "satooshi/php-coveralls" : "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     },
     "require": {
         "php": ">=7.1",
-        "laravel/framework": "^5.6"
+        "laravel/framework": "^5.6|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
-        "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit": "~7.0|~8.0",
         "squizlabs/php_codesniffer" : "1.5.*",
-        "laravel/laravel": "^5.6",
+        "laravel/laravel": "^5.6|^6.0",
         "satooshi/php-coveralls" : "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,13 @@
     },
     "require": {
         "php": ">=7.1",
-        "laravel/framework": "^5.6|^6.0"
+        "laravel/framework": "^5.6"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
-        "phpunit/phpunit": "~7.0|~8.0",
+        "phpunit/phpunit": "~7.0",
         "squizlabs/php_codesniffer" : "1.5.*",
-        "laravel/laravel": "^5.6|^6.0",
+        "laravel/laravel": "^5.6",
         "satooshi/php-coveralls" : "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
This change makes this package work with Laravel 6. Take not it now requires adding the new support package called: laravel/helpers
array_xxx helpers was deprecated in 6.0