### PR TITLE
Return full trans with args when translations missing.

### DIFF
--- a/src/Xinax/LaravelGettext/Support/helpers.php
+++ b/src/Xinax/LaravelGettext/Support/helpers.php
@@ -18,24 +18,19 @@ if (!function_exists('_i')) {
         $translator  = app(LaravelGettext::class);
         $translation = $translator->translate($message);
 
-        if (strlen($translation)) {
-            if (isset($args)) {
-                if (!is_array($args)) {
-                    $args = array_slice(func_get_args(), 1);
-                }
-                $translation = vsprintf($translation, $args);
-            }
-
-            return $translation;
+        // Use original message as fallback.
+        if (!strlen($translation)) {
+            $translation = $message;
         }
 
-        /**
-         * If translations are missing returns
-         * the original message.
-         *
-         * @see https://github.com/symfony/symfony/issues/13483
-         */
-        return $message;
+        if (isset($args)) {
+            if (!is_array($args)) {
+                $args = array_slice(func_get_args(), 1);
+            }
+            $translation = vsprintf($translation, $args);
+        }
+
+        return $translation;
     }
 }
 


### PR DESCRIPTION
With current approach `_i('Hello %s', $userName)` only returns `Hello %s` if no translation available.