### PR TITLE
Fixes Symfony\Component\ErrorHandler\Error\FatalError exception

### DIFF
--- a/src/Xinax/LaravelGettext/FileLoader/Cache/ApcuFileCacheLoader.php
+++ b/src/Xinax/LaravelGettext/FileLoader/Cache/ApcuFileCacheLoader.php
@@ -37,7 +37,7 @@ class ApcuFileCacheLoader extends FileLoader
      *
      * @throws InvalidResourceException if stream content has an invalid format
      */
-    protected function loadResource($resource)
+    protected function loadResource(string $resource): array
     {
         if (!extension_loaded('apcu')) {
             return $this->underlyingFileLoader->loadResource($resource);

--- a/src/Xinax/LaravelGettext/FileLoader/MoFileLoader.php
+++ b/src/Xinax/LaravelGettext/FileLoader/MoFileLoader.php
@@ -40,7 +40,7 @@ class MoFileLoader extends FileLoader
      *
      * {@inheritdoc}
      */
-    protected function loadResource($resource)
+    protected function loadResource(string $resource): array
     {
         $stream = fopen($resource, 'r');
 


### PR DESCRIPTION
Since Symfony translation FileLoader now using type-hints, it should fix fatal error on php 8.1