### PR TITLE
Add Laravel 11 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,14 @@
     },
     "require": {
         "php": ">=7.2",
-        "laravel/framework": "^6.0 || ^7.0 || ^8.0",
+        "laravel/framework": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "laravel/helpers": "^1.1"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",
         "phpunit/phpunit": "~7.0 || ^8.5 || ^9",
         "squizlabs/php_codesniffer" : "1.5.*",
-        "laravel/laravel": "^6.0 || ^7.0 || ^8.0",
+        "laravel/laravel": "^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {


### PR DESCRIPTION
Updated composer.json to include specific version requirements. This configuration has been tested and used in my fork for over a year without any issues.